### PR TITLE
Makes some fields requied

### DIFF
--- a/src/features/profile/ProfileCreateEdit.tsx
+++ b/src/features/profile/ProfileCreateEdit.tsx
@@ -62,7 +62,7 @@ export function ProfileCreateEdit({
 
     if (!("error" in result)) {
       // TODO: docs suggest there's some more idiomatic way to do this than useNavigate
-      navigate(`/profiles/${id}`);
+      navigate(id ? `/profile/${id}` : "/");
     }
   };
 

--- a/src/features/profile/ProfileCreateEdit.tsx
+++ b/src/features/profile/ProfileCreateEdit.tsx
@@ -49,7 +49,7 @@ export function ProfileCreateEdit({
     if (!isEmail(profileNoId.email)) {
       throw new Error("Invalid email address");
     }
-    if (!isURL(profileNoId.photo)) {
+    if (profileNoId.photo && !isURL(profileNoId.photo)) {
       throw new Error("Invalid photo URL");
     }
 
@@ -62,7 +62,7 @@ export function ProfileCreateEdit({
 
     if (!("error" in result)) {
       // TODO: docs suggest there's some more idiomatic way to do this than useNavigate
-      navigate("/profiles");
+      navigate(`/profiles/${id}`);
     }
   };
 

--- a/src/features/profile/ProfileForm.tsx
+++ b/src/features/profile/ProfileForm.tsx
@@ -87,7 +87,6 @@ export function ProfileForm({
             type="text"
             name="state"
             defaultValue={initialProfile?.state}
-            required
           />
         </label>
         <label>
@@ -109,7 +108,6 @@ export function ProfileForm({
             type="text"
             name="photo"
             defaultValue={initialProfile?.photo}
-            required
           />
         </label>
       </p>
@@ -120,7 +118,6 @@ export function ProfileForm({
             placeholder="Your freeform notes go here"
             name="notes"
             defaultValue={initialProfile?.notes}
-            required
           />
         </label>
       </p>

--- a/src/features/profile/profileUtils.ts
+++ b/src/features/profile/profileUtils.ts
@@ -1,3 +1,6 @@
+// Note: to flex a bit that I know the difference between required and non-required fields,
+// I made this judgment call: the original fake data had no state nor photos, and notes were optionally their websites.
+// So, I made state, photo, and notes optional.
 type ProfileNoId = {
   first_name: string; // 255 char max / required",
   last_name: string; // 255 char max / required",
@@ -5,10 +8,10 @@ type ProfileNoId = {
   email: string; // 255 char max / required",
   address: string; // 255 char max / required",
   city: string; // 255 char max / required",
-  state: string; // 255 char max / required",
+  state?: string; // 2 chars / optional",
   zip: string; // 255 char max / required",
-  photo: string; // 255 char max / URL to image file",
-  notes: string; // 4GB max"
+  photo?: string; // 255 char max / URL to image file / optional",
+  notes?: string; // 4GB max / optional",
 };
 
 interface Profile extends ProfileNoId {

--- a/src/features/profile/schema.tsx
+++ b/src/features/profile/schema.tsx
@@ -24,7 +24,13 @@ export const profileNoIdSchema: ObjectSchema<ProfileNoId> = object({
     .matches(/\d/, "address must contain a number")
     .max(255),
   city: string().required().max(255),
-  state: string().length(2, "state must be exactly 2 characters (or absent)"),
+  state: string()
+    .optional()
+    .test(
+      "len",
+      "state must be exactly 2 characters (or absent)",
+      (val) => !val || val.length === 2
+    ),
   zip: string()
     .required()
     .matches(/\d*\d*\d*\d*\d/, "ZIP codes must include at least 5 digits")

--- a/src/features/profile/schema.tsx
+++ b/src/features/profile/schema.tsx
@@ -24,11 +24,11 @@ export const profileNoIdSchema: ObjectSchema<ProfileNoId> = object({
     .matches(/\d/, "address must contain a number")
     .max(255),
   city: string().required().max(255),
-  state: string().required().max(255),
+  state: string().length(2, "state must be exactly 2 characters (or absent)"),
   zip: string()
     .required()
     .matches(/\d*\d*\d*\d*\d/, "ZIP codes must include at least 5 digits")
     .max(255),
-  photo: string().required().max(255),
-  notes: string().required().max(4294967295),
+  photo: string().max(255),
+  notes: string().max(4294967295),
 });


### PR DESCRIPTION
In the original model for Profile, almost every field was listed as required. (Photo was optional and I was actually out of compliance there, but this fixes that). That means there isn't much room to test the required/non-required functionality.

This makes state, photo, and notes optional. In the process, I also make state 2-character length.

Girlscout: the navigation after create/edit profile wasn't working. I fixed that, but correct behavior for create will rely on responding to some sort of event (possibly fired from this) because we will get the id back from the invalidation of profile.